### PR TITLE
Fixed ignored sortBy & sortDir snippet params

### DIFF
--- a/core/components/pdotools/elements/snippets/snippet.pdositemap.php
+++ b/core/components/pdotools/elements/snippets/snippet.pdositemap.php
@@ -50,8 +50,16 @@ if (!empty($startId)) {
 		$parents = $startId;
 	}
 }
-if (!empty($sortBy)) {$sortby = $sortBy;}
-if (!empty($sortDir)) {$sortdir = $sortDir;}
+if (!empty($sortBy)) {
+	$sortby = $sortBy;
+	$scriptProperties['sortby'] = $sortby;
+	unset($scriptProperties['sortBy']);
+}
+if (!empty($sortDir)) {
+	$sortdir = $sortDir;
+	$scriptProperties['sortdir'] = $sortdir;
+	unset($scriptProperties['sortDir']);
+}
 if (!empty($priorityTV)) {
 	if (!empty($scriptProperties['includeTVs'])) {
 		$scriptProperties['includeTVs'] .= ','.$priorityTV;


### PR DESCRIPTION
I had the problem, that the generated sitemap was not nicely sorted as parent, parent/subsite1.html, parent/subsite2.html but accordingly to the menuindex in general (so each resource with a menuindex of 0 in the respective parent showed up after each other, not sorted by menuindex for that parent) I then tried to specify &sortBy=`parent,menuindex` but the params were not taken over into the config for pdoFetch but still had the default value of menuindex...I digged a bit and found they were not there in the merged config array because they (sortby/sortdir) were not present in the $scriptProperties array. Now when I specify &sortBy=`parent,menuindex` it works properly
