### PR TITLE
Add check value ID

### DIFF
--- a/core/components/pdotools/model/pdotools/pdomenu.class.php
+++ b/core/components/pdotools/model/pdotools/pdomenu.class.php
@@ -44,7 +44,7 @@ class pdoMenu {
 			$config['tplInner'] = $config['tplOuter'];
 		}
 		if (empty($config['hereId'])) {
-			$config['hereId'] = $modx->resource->id;
+			$config['hereId'] = ((trim($modx->resource->id))=='')?'1':$modx->resource->id;
 		}
 
 		$fqn = $modx->getOption('pdoFetch.class', null, 'pdotools.pdofetch', true);


### PR DESCRIPTION
Когда вызываю pdoMenu в шаблоне для Sendex то 

```
$modx->resource->id
```

При пустом кэше возращает пустоту. в следствии чего генерируется ошибка:

```
(ERROR @ /paas/c2135/www/core/components/pdotools/model/pdotools/pdomenu.class.php : 64) PHP warning: array_flip(): Can only flip STRING and INTEGER values!
```
