### PR TITLE
[pdoField] get the default, only if the field was empty

### DIFF
--- a/core/components/pdotools/elements/snippets/snippet.pdofield.php
+++ b/core/components/pdotools/elements/snippets/snippet.pdofield.php
@@ -107,17 +107,23 @@ if (!empty($default)) {
 
 $scriptProperties['disableConditions'] = true;
 if ($row = $pdoFetch->getObject($class, $where, $scriptProperties)) {
-	foreach ($row as $k => $v) {
-		$k = strtolower($k);
-		if ($k == $field && $v != '') {
-			$output = $v;
-			break;
-		}
-		elseif ($k == $default && $v != '') {
-			$output = $v;
-			break;
-		}
-	}
+    foreach ($row as $k => $v) {
+        $k = strtolower($k);
+        if ($k == $field && $v != '') {
+            $output = $v;
+            break;
+        }
+    }
+
+    if (empty($output) && !empty($default)) {
+        foreach ($row as $k => $v) {
+            $k = strtolower($k);
+            if ($k == $default && $v != '') {
+                $output = $v;
+                break;
+            }
+        }
+    }
 }
 
 if (!empty($toPlaceholder)) {


### PR DESCRIPTION
pdoField did get the default, when it was before the field in the row, also when field was not empty
