### PR TITLE
Hack for snippets or modifiers in @INLINE

### DIFF
--- a/core/components/pdotools/model/pdotools/pdotools.class.php
+++ b/core/components/pdotools/model/pdotools/pdotools.class.php
@@ -491,6 +491,7 @@ class pdoTools {
 			$content = substr($name, strlen($binding) + 1);
 		}
 		$content = ltrim($content, ' :');
+		$content = str_replace(array('{{','}}'), array('[[',']]'), $content);
 
 		// Change name for empty TEMPLATE binding so will be used template of given row
 		if ($binding == 'TEMPLATE' && empty($content) && isset($row['template'])) {


### PR DESCRIPTION
Это, наверное, очень грязный хак, но он позволит использовать в инлайн-чанках сниппеты и модификаторы вывода вот так:
`{{+publishedon:date=`%d.%m.%Y г.`}}`
`{{+tv.img:phpthumbon=`w=100&h=100&zc=1`}}`
