### PR TITLE
Fixes order for children of excluded parents

### DIFF
--- a/core/components/pdotools/model/pdotools/pdotools.class.php
+++ b/core/components/pdotools/model/pdotools/pdotools.class.php
@@ -616,7 +616,7 @@ class pdoTools {
 			}
 
 			foreach ($rows as $id => &$row) {
-				if (empty($row[$parent])) {
+				if (empty($row[$parent]) || empty($rows[$row[$parent]])) {
 					$tree[$id] = &$row;
 				}
 				else{


### PR DESCRIPTION
Fixes an issue where children of excluded parents always get appended to end of the tree, not according to their order.
