### PR TITLE
Добавить поддержку комплексных параметров с TV в where

### DIFF
--- a/core/components/pdotools/model/pdotools/pdofetch.class.php
+++ b/core/components/pdotools/model/pdotools/pdofetch.class.php
@@ -832,8 +832,9 @@ class pdoFetch extends pdoTools {
 			if (is_numeric($k) && is_string($v)) {
 				$tmp = preg_replace_callback('/\b('.$tvs.')\b/i', $callback, $v);
 				$sorts[$k] = $tmp;
-			}
-			else {
+			} elseif(is_numeric($k) && is_array($v)) {
+				$sorts[$k]=$this->replaceTVCondition($v);
+			} else {
 				$tmp = preg_replace_callback('/\b('.$tvs.')\b/i', $callback, $k);
 				$sorts[$tmp] = $v;
 			}


### PR DESCRIPTION
Обновление добавляет поддержку сложных запросов с полями TV в поле where. Сейчас если сделан дополнительный вложенный массив для генерации запросов вида (A AND (B OR (C AND D)) поля TV не обрабатываются и не заменяются. Данное обновление исправляет приведённое замечание.

Signed-off-by: Egor Bolgov egor.b@webvortex.ru
