### PR TITLE
Доступ к конфигу pdoPage извне.

### DIFF
--- a/core/components/pdotools/model/pdotools/pdopage.class.php
+++ b/core/components/pdotools/model/pdotools/pdopage.class.php
@@ -66,7 +66,8 @@ class pdoPage {
 			assetsUrl: "' . $assetsUrl . '"
 		}';
 		$this->modx->regClientStartupScript('<script type="text/javascript">pdoPage = {callbacks: {}, keys: {}};</script>', true);
-		$this->modx->regClientScript('<script type="text/javascript">pdoPage.initialize(' . $config . ');</script>', true);
+		$this->modx->regClientScript('<script type="text/javascript">pdoPage.config = ' . $config . ';</script>', true);
+		$this->modx->regClientScript('<script type="text/javascript">pdoPage.initialize(pdoPage.config);</script>', true);
 	}
 
 


### PR DESCRIPTION
Небольшое изменение, для того чтобы можно было получить извне доступ к конфигу pdoPage в своём скрипте. По-хорошему надо так было делать изначально и обращаться к config внутри скрипта pdopage.js не как с локальной переменной, а как к свойству класса pdoPage.
