### PR TITLE
Possible typo fixed

### DIFF
--- a/core/components/pdotools/model/pdotools/pdotools.class.php
+++ b/core/components/pdotools/model/pdotools/pdotools.class.php
@@ -409,7 +409,7 @@ class pdoTools {
 	public function fenom($chunk, array $properties = array()) {
 		if (is_array($chunk)) {
 			if (empty($chunk['content'])) {
-				return $chunk;
+				return $chunk['content'];
 			}
 			else {
 				$content = trim($chunk['content']);


### PR DESCRIPTION
Похоже на опечатку, поскольку если возвращать массив, дальше по коду к нему применяются строковые функции, что приводит к предупреждениям в логах.
