### PR TITLE
Added ajaxPlaceholder property

### DIFF
--- a/core/components/pdotools/elements/snippets/snippet.pdopage.php
+++ b/core/components/pdotools/elements/snippets/snippet.pdopage.php
@@ -9,6 +9,7 @@ if (empty($page)) {$page = 1;}
 if (empty($pageLimit)) {$pageLimit = 5;} else {$pageLimit = (integer) $pageLimit;}
 if (!isset($plPrefix)) {$plPrefix = '';}
 if (!empty($scriptProperties['ajaxMode'])) {$scriptProperties['ajax'] = 1;}
+if (!empty($scriptProperties['ajaxPlaceholder'])) {$scriptProperties['ajaxPlaceholder'] = explode(',',$scriptProperties['ajaxPlaceholder']);}
 
 // Convert parameters from getPage if exists
 if (!empty($namespace)) {$plPrefix = $namespace;}
@@ -197,6 +198,12 @@ if ($isAjax) {
 	if ($totalVar != 'total') {
 		$data['total'] = (int)$data[$totalVar];
 		unset($data[$totalVar]);
+	}
+	
+	if ($scriptProperties['ajaxPlaceholder']) {
+	    foreach($scriptProperties['ajaxPlaceholder'] as $placeholder) {
+        	$data[$placeholder] = $modx->getPlaceholder($placeholder);
+	    }
 	}
 
 	@session_write_close();


### PR DESCRIPTION
Maybe this addition is useful for others: Add additional keys to the AJAX result. These keys are filled by placeholder values set on the page with the pdoPage call. The property has to be filled with a comma separated list of placeholder names.
