### PR TITLE
defalut value for showhidden

### DIFF
--- a/_build/properties/properties.pdoresources.php
+++ b/_build/properties/properties.pdoresources.php
@@ -119,7 +119,7 @@ $tmp = array(
 	)
 	,'showHidden' => array(
 		'type' => 'combo-boolean'
-		,'value' => true
+		,'value' => false
 	)
 	,'hideContainers' => array(
 		'type' => 'combo-boolean'


### PR DESCRIPTION
In pdoResources, the default value for showhidden is true, I have changed that to false. If it is true on purpose, Kindly ignore it. Thanks.
