### PR TITLE
Update _micromodx.php

### DIFF
--- a/core/components/pdotools/model/pdotools/_micromodx.php
+++ b/core/components/pdotools/model/pdotools/_micromodx.php
@@ -149,7 +149,7 @@ class microMODX {
 	 */
 	public function makeUrl($id, $context = '', $args = '', $scheme = -1, array $options = array()) {
 		$this->debugParser('makeUrl', $id, $args);
-		$result = $this->modx->makeUrl($id, $context, $args, $scheme, $options);
+		$result = $id ? $this->modx->makeUrl($id, $context, $args, $scheme, $options) : '';
 		$this->debugParser('makeUrl', $id, $args);
 
 		return $result;


### PR DESCRIPTION
Если передать в $_modx->makeUrl ноль, то лог наполняется такими ошибками - "`0` is not a valid integer and may not be passed to makeUrl()"
Это может получится тогда, когда переменной в шаблоне присваиваем результат работы сниппета BabelTranslation, а страницы такой в текущей языковой версии нет, следовательно сниппет возвращает 0.
