### PR TITLE
2.5.7 pl

### DIFF
--- a/_build/build.config.php
+++ b/_build/build.config.php
@@ -4,7 +4,7 @@
 define('PKG_NAME', 'pdoTools');
 define('PKG_NAME_LOWER', strtolower(PKG_NAME));
 
-define('PKG_VERSION', '2.5.6');
+define('PKG_VERSION', '2.5.7');
 define('PKG_RELEASE', 'pl');
 define('PKG_AUTO_INSTALL', true);
 
@@ -38,7 +38,7 @@ define('BUILD_SETTING_UPDATE', false);
 
 define('BUILD_SNIPPET_UPDATE', true);
 define('BUILD_PLUGIN_UPDATE', true);
-//define('BUILD_EVENT_UPDATE', true);
+define('BUILD_EVENT_UPDATE', true);
 //define('BUILD_POLICY_UPDATE', true);
 //define('BUILD_POLICY_TEMPLATE_UPDATE', true);
 //define('BUILD_PERMISSION_UPDATE', true);

--- a/_build/build.transport.php
+++ b/_build/build.transport.php
@@ -65,6 +65,25 @@ if (defined('BUILD_SETTING_UPDATE')) {
     unset($settings, $setting, $attributes);
 }
 
+/* load plugins events */
+if (defined('BUILD_EVENT_UPDATE')) {
+    $events = include $sources['data'] . 'transport.events.php';
+    if (!is_array($events)) {
+        $modx->log(modX::LOG_LEVEL_ERROR, 'Could not package in events.');
+    } else {
+        $attributes = array(
+            xPDOTransport::PRESERVE_KEYS => true,
+            xPDOTransport::UPDATE_OBJECT => BUILD_EVENT_UPDATE,
+        );
+        foreach ($events as $event) {
+            $vehicle = $builder->createVehicle($event, $attributes);
+            $builder->putVehicle($vehicle);
+        }
+        $modx->log(xPDO::LOG_LEVEL_INFO, 'Packaged in ' . count($events) . ' Plugins events.');
+    }
+    unset ($events, $event, $attributes);
+}
+
 /* create category */
 $category = $modx->newObject('modCategory');
 $category->set('id', 1);

--- a/_build/data/transport.events.php
+++ b/_build/data/transport.events.php
@@ -1,0 +1,19 @@
+<?php
+
+$events = array();
+
+$tmp = array(
+    'pdoToolsOnFenomInit',
+);
+
+foreach ($tmp as $k => $v) {
+    /* @var modEvent $event */
+    $event = $modx->newObject('modEvent');
+    $event->fromArray(array(
+        'name'      => $v,
+        'service'   => 6,
+        'groupname' => PKG_NAME,
+    ), '', true, true);
+    $events[] = $event;
+}
+return $events;

--- a/core/components/pdotools/docs/changelog.txt
+++ b/core/components/pdotools/docs/changelog.txt
@@ -1,5 +1,9 @@
 Changelog for pdoTools.
 
+2.5.7 pl
+==============
+- Add event "pdoToolsOnFenomInit".
+
 2.5.6 pl
 ==============
 - [pdoFetch] Ability to join TVs not only to the query main class.

--- a/core/components/pdotools/model/pdotools/_fenom.php
+++ b/core/components/pdotools/model/pdotools/_fenom.php
@@ -55,6 +55,15 @@ class FenomX extends Fenom
         $this->modx = $pdoTools->modx;
 
         $this->_addDefaultModifiers();
+
+        $this->modx->invokeEvent(
+            'pdoToolsOnFenomInit',
+            array(
+                'fenom' => $this,
+                'config' => $pdoTools->config
+            )
+        );
+
     }
 
 


### PR DESCRIPTION
# 
- Add event "pdoToolsOnFenomInit".

ex:

```
switch ($modx->event->name) {

    case 'pdoToolsOnFenomInit':

    if (!$fenom = $modx->getOption('fenom', $scriptProperties)) {
        return;
    }


    $fenom->addModifier("zzz", function ($value) {
            return 'zzz';
        });

        if (!$miniShop2 = $modx->getService('miniShop2')
        ) {
            return false;
        }
        $fenom->miniShop2 = $miniShop2;
        $fenom->addAccessorSmart("miniShop2", "miniShop2", Fenom::ACCESSOR_PROPERTY);

        break;
}
```
