### PR TITLE
Парсинг вложенных JSON-массивов

### DIFF
--- a/core/components/pdotools/model/pdotools/pdotools.class.php
+++ b/core/components/pdotools/model/pdotools/pdotools.class.php
@@ -1029,7 +1029,7 @@ class pdoTools
             // Extract JSON fields
             if ($this->config['decodeJSON']) {
                 foreach ($row as $k => $v) {
-                    if (!empty($v) && is_string($v) && strlen($v) >= 2 && (($v[0] == '{' && $v[1] == '"') || ($v[0] == '[' && $v[1] != '['))) {
+                    if (!empty($v) && is_string($v) && strlen($v) >= 2 && (($v[0] == '{' && $v[1] == '"') || ($v[0] == '[' && $v[1] != '[') || (strlen($v) >= 4 && $v[0] == '[' && $v[1] == '[' && ($v[2] == ' ' || $v[2] == ']' || $v[2] == '[' || $v[2] == '{' || $v[2] == '"' || is_numeric($v[2]))))) {
                         $tmp = $this->modx->fromJSON($v);
                         if ($tmp !== null) {
                             $row[$k] = $tmp;


### PR DESCRIPTION
Исправляем баг с тем, что JSON-строка с вложенными JSON-массивами не обрабатывается.
Например, [[], {"foo":"bar"}]
Исправление рассчитано на то, что имена сниппетов начинаются с буквы. А следовательно, в валидной JSON-строке с большой вероятностью на третьем месте может находится цифра ( [[23, 45], [24, 56]] ), закрывающая квадратная скобка ( [[], []] ), пробел ( [[ 45, 16 ] , [ 32, 48 ]] ), открывающие фигурная или квадратная скобка (  [[{"foo":"bar"}, {"bar":"foo"}]]) или кавычка ( [["foo", "bar"], []])
