### PR TITLE
_micromodx::runSnippet() return @array type feature for use with Fenom

### DIFF
--- a/core/components/pdotools/model/pdotools/_micromodx.php
+++ b/core/components/pdotools/model/pdotools/_micromodx.php
@@ -108,12 +108,15 @@ class microMODX
      * @param $name
      * @param array $params
      *
-     * @return string
+     * @return array|string
      */
     public function runSnippet($name, array $params = array())
     {
         $this->pdoTools->debugParserMethod('runSnippet', $name, $params);
-        $output = (string)$this->pdoTools->runSnippet($name, $params);
+        $output = $this->pdoTools->runSnippet($name, $params);
+        if (!is_array($output)) {
+            $output = (string)$output;
+        }
         $this->pdoTools->debugParserMethod('runSnippet', $name, $params);
 
         return $output;


### PR DESCRIPTION
**Что это делает?**

Позволяет возвращать массив при вызове через $_modx->runSnippet()

**Зачем это нужно?**

Для сохранения обратной совместимости проектов, если результат работы сниппета записывается в плейсхолдер и обрабатывается далее через {foreach}{/foreach}

