### PR TITLE
A little improvement for resource modifier

### DIFF
--- a/core/components/pdotools/model/pdotools/_fenom.php
+++ b/core/components/pdotools/model/pdotools/_fenom.php
@@ -401,7 +401,9 @@ class FenomX extends Fenom
         $this->_modifiers['resource'] = function ($id, $field = null) use ($pdo, $modx, $fenom) {
             $pdo->debugParserModifier($id, 'resource');
             /** @var modResource $resource */
-            if (empty($id)) {
+                $field = $id;
+                $resource = $modx->resource;
+            } elseif (empty($id)) {
                 $resource = $modx->resource;
             } elseif (!$resource = $pdo->getStore($id, 'resource')) {
                 $resource = $modx->getObject('modResource', $id);

--- a/core/components/pdotools/model/pdotools/_fenom.php
+++ b/core/components/pdotools/model/pdotools/_fenom.php
@@ -401,6 +401,7 @@ class FenomX extends Fenom
         $this->_modifiers['resource'] = function ($id, $field = null) use ($pdo, $modx, $fenom) {
             $pdo->debugParserModifier($id, 'resource');
             /** @var modResource $resource */
+            if (!empty($id) && is_string($id)) {
                 $field = $id;
                 $resource = $modx->resource;
             } elseif (empty($id)) {


### PR DESCRIPTION
Now it's able to get field from current resource without its id or by
filling id with empty string.

Now you can get current resource pagetitle by:
```
{'pagetitle' | resource}
```
instead of one of these:
```
{'' | resource : 'pagetitle'}
{$_modx->resource.id}
```