### PR TITLE
Fix pdofetch.class.php for PHP7

### DIFF
--- a/core/components/pdotools/model/pdotools/pdofetch.class.php
+++ b/core/components/pdotools/model/pdotools/pdofetch.class.php
@@ -150,6 +150,9 @@ class pdoFetch extends pdoTools
                         }
 
                         $tpl = $this->defineChunk($row);
+                        if(empty($output)){
+                            $output = [];
+                        }
                         if (empty($tpl)) {
                             $output[] = '<pre>' . $this->getChunk('', $row) . '</pre>';
                         } else {


### PR DESCRIPTION
Fix error for PHP7
PHP Fatal error:  Uncaught Error: [] operator not supported for strings in /var/www/html/core/components/pdotools/model/pdotools/pdofetch.class.php:155"
