### PR TITLE
Fixing a missing pagination in Ajax mode

### DIFF
--- a/core/components/pdotools/elements/snippets/snippet.pdopage.php
+++ b/core/components/pdotools/elements/snippets/snippet.pdopage.php
@@ -197,6 +197,17 @@ if (empty($data)) {
         $pagination = !empty($tplPageWrapper)
             ? $pdoPage->pdoTools->getChunk($tplPageWrapper, $pagination)
             : $pdoPage->pdoTools->parseChunk('', $pagination);
+    } else {
+        $pagination = array(
+            'first' => '',
+            'prev' => '',
+            'pages' => '',
+            'next' => '',
+            'last' => ''
+        );
+        $pagination = !empty($tplPageWrapper)
+            ? $pdoPage->pdoTools->getChunk($tplPageWrapper, $pagination)
+            : $pdoPage->pdoTools->parseChunk('', $pagination);
     }
 
     $data = array(


### PR DESCRIPTION
This issue was introduced with #244. Since replaceWith replaces the pagination block, the DOM element misses after an empty pagination occured and can't be restored afterwards.