### PR TITLE
[Fenom] Сохранение контента при ошибке

### DIFF
--- a/core/components/pdotools/model/pdotools/pdotools.class.php
+++ b/core/components/pdotools/model/pdotools/pdotools.class.php
@@ -941,6 +941,9 @@ class pdoTools
             } catch (Exception $e) {
                 $this->modx->log(modX::LOG_LEVEL_ERROR, $e->getMessage());
                 $this->modx->log(modX::LOG_LEVEL_INFO, $content);
+                if ($this->modx->getOption('log_compiled_on_error')) {
+                    $this->setCache($content, array('cache_key' => 'pdotools/' . $name));
+                }
             }
         }
         $this->addTime('Compiled Fenom chunk with name "' . $name . '"');


### PR DESCRIPTION
В случае ошибки при компиляции контента шаблонизатором Fenom сохранять в папку core/cache/default/pdotools этот контент для упрощения отладки. Управляется данная возможность соответствующей системной настройкой log_compiled_on_error.