### PR TITLE
Уточнение url в rel="canonical"

### DIFF
--- a/core/components/pdotools/elements/snippets/snippet.pdopage.php
+++ b/core/components/pdotools/elements/snippets/snippet.pdopage.php
@@ -184,15 +184,16 @@ if (empty($data)) {
         }
 
         if (!empty($setMeta) && !$isAjax) {
-            $modx->regClientStartupHTMLBlock('<link rel="canonical" href="' . $url . '"/>');
+            $canurl = $modx->getOption('url_scheme') . $modx->getOption('http_host') . $url;
+            $modx->regClientStartupHTMLBlock('<link rel="canonical" href="' . $canurl . '"/>');
             if ($page > 1) {
                 $modx->regClientStartupHTMLBlock(
-                    '<link rel="prev" href="' . $pdoPage->makePageLink($url, $page - 1) . '"/>'
+                    '<link rel="prev" href="' . $pdoPage->makePageLink($canurl, $page - 1) . '"/>'
                 );
             }
             if ($page < $pageCount) {
                 $modx->regClientStartupHTMLBlock(
-                    '<link rel="next" href="' . $pdoPage->makePageLink($url, $page + 1) . '"/>'
+                    '<link rel="next" href="' . $pdoPage->makePageLink($canurl, $page + 1) . '"/>'
                 );
             }
         }


### PR DESCRIPTION
При формировании rel="canonical", а так же rel="prev" и rel="next" поисковики, в первую очередь Google, рекомендуют использовать абсолютный путь. Если при вызове сниппета задать формирование относительных ссылок (например &scheme=`abs`), то ссылки в rel="canonical" буду формироваться относительными, что не рекомендуется. Предлагаю скорректировать это поведение следующим уточнением.