### PR TITLE
[pdoFetch] HAVING по голому SQL

### DIFF
--- a/core/components/pdotools/model/pdotools/pdofetch.class.php
+++ b/core/components/pdotools/model/pdotools/pdofetch.class.php
@@ -230,6 +230,9 @@ class pdoFetch extends pdoTools
             if (is_string($tmp) && ($tmp[0] == '{' || $tmp[0] == '[')) {
                 $tmp = json_decode($tmp, true);
             }
+            if (!is_array($tmp)) {
+                $tmp = array($tmp);
+            }
             $having = $this->replaceTVCondition($tmp);
             $this->query->having($having);
 


### PR DESCRIPTION
В данный момет, если передать в HAVING строку SQL -- все ломается. Причина -- replaceTVCondition() ожидает на вход массив. По аналогии с WHERE добавил проверку является ли переданная переменная массивом. Если нет -- оборачиваем её массивом.