### PR TITLE
More perfomance when use prepareSnippet

### DIFF
--- a/core/components/pdotools/model/pdotools/pdotools.class.php
+++ b/core/components/pdotools/model/pdotools/pdotools.class.php
@@ -1166,10 +1166,12 @@ class pdoTools
                 'pdoFetch' => $this,
                 'row' => $row,
             )));
-
-            $tmp = ($tmp[0] == '[' || $tmp[0] == '{')
-                ? json_decode($tmp, true)
-                : unserialize($tmp);
+            
+            if (!is_array($tmp)){
+                $tmp = ($tmp[0] == '[' || $tmp[0] == '{')
+                    ? json_decode($tmp, true)
+                    : unserialize($tmp);
+            }
 
             if (!is_array($tmp)) {
                 $this->addTime('Preparation snippet must return an array, instead of "' . gettype($tmp) . '"');


### PR DESCRIPTION
При использовании `prepareSnippet` можно не преобразовывать в json возвращаемый сниппетом массив `$row`. При этом возрастает скорость отдачи странички (быстрее на 40-50мс, вывод 110 элементов, процессор i7 2,2Ghz, macOS, php7).