### PR TITLE
Fix detection of names starting with a number

### DIFF
--- a/core/components/pdotools/model/pdotools/pdotools.class.php
+++ b/core/components/pdotools/model/pdotools/pdotools.class.php
@@ -896,9 +896,19 @@ class pdoTools
                 }
                 break;
             default:
-                $c = ($type == 'modTemplate')
-                    ? array('id' => $cache_name, 'OR:templatename:=' => $cache_name)
-                    : array('id' => $cache_name, 'OR:name:=' => $cache_name);
+                if ($type == 'modTemplate') {
+                    if(filter_var($cache_name, FILTER_VALIDATE_INT) === false) {
+                        $c = array('templatename:=' => $cache_name);
+                    } else {
+                        $c = array('id:=' => $cache_name);
+                    }
+                } else {
+                    if(filter_var($cache_name, FILTER_VALIDATE_INT) === false) {
+                        $c = array('name:=' => $cache_name);
+                    } else {
+                        $c = array('id:=' => $cache_name);
+                    }
+                }
                 if ($element = $this->modx->getObject($type, $c)) {
                     $content = $element->getContent();
                     if (!empty($propertySet)) {

--- a/core/components/pdotools/model/pdotools/pdotools.class.php
+++ b/core/components/pdotools/model/pdotools/pdotools.class.php
@@ -896,18 +896,11 @@ class pdoTools
                 }
                 break;
             default:
-                if ($type == 'modTemplate') {
-                    if(filter_var($cache_name, FILTER_VALIDATE_INT) === false) {
-                        $c = array('templatename:=' => $cache_name);
-                    } else {
-                        $c = array('id:=' => $cache_name);
-                    }
+                $column = ($type == 'modTemplate') ? 'templatename' : 'name';
+                if (filter_var($cache_name, FILTER_VALIDATE_INT) === false) {
+                    $c = array($column . ':=' => $cache_name);
                 } else {
-                    if(filter_var($cache_name, FILTER_VALIDATE_INT) === false) {
-                        $c = array('name:=' => $cache_name);
-                    } else {
-                        $c = array('id:=' => $cache_name);
-                    }
+                    $c = array('id:=' => $cache_name, 'OR:' . $column . ':=' => $cache_name);
                 }
                 if ($element = $this->modx->getObject($type, $c)) {
                     $content = $element->getContent();


### PR DESCRIPTION
Bug: A chunk name starting with a number leads to using the chunk with that ID. Example: ```&tpl=`15_whatever` ``` leads to use the chunk with the ID 15. 

The code fixes this issue.