### PR TITLE
Fix error cache

### DIFF
--- a/core/components/pdotools/model/pdotools/pdotools.class.php
+++ b/core/components/pdotools/model/pdotools/pdotools.class.php
@@ -1381,7 +1381,10 @@ class pdoTools
                 ? (integer)$options['cacheTime']
                 : (integer)$this->modx->getOption('cache_resource_expires', null, 0),
         );
-
+        
+        unset($options['setTotal']);
+        unset($options['request']);
+        
         return $cacheOptions;
     }
 


### PR DESCRIPTION
pdoPage отрабатывает за 88мс и явно не кешируется. Полез разбираться и обнаружил 2 ошибки с кешем в нем.
Сделал вывод имен файлов кеша. Запрашиваемое имя и записываемое. Обнаружил:
No cached data for key "resource/web/resources/89/4e61020450c4424d73d66aee8a9324bfe0a70960"
cacheKey web/resources/89/4ccd1f1b0b32e54c8ce591eca2270b39c739fdfc
Запрашивается имя кеша одно, а записывается другое. Нашел, что имя кеша генерируется в файле core/components/pdotools/model/pdotools/pdotools.class.php функция protected function getCacheKey($options = array())
return $key . '/' . sha1(serialize($options));
где $options — это $scriptProperties сниппета. Для запрашиваемого и записываемого имени кеша $scriptProperties в функцию попадают разные. В сниппете pdoPage
$data = $cache
    ? $pdoPage->pdoTools->getCache($scriptProperties)
    : array();
//echo "<pre>".print_r($data,1)."</pre>";

if (empty($data)) {
    $scriptProperties['setTotal'] = true;
то есть после запроса кеша в $scriptProperties записывается setTotal и соответственно генерируемое имя файла кеша изменяется. Для обхода этой ошибки в функции getCacheKey перед генерацией имени файла кеша сделал
unset($options['setTotal']);
return $key . '/' . sha1(serialize($options));
Вторая ошибка: в $scriptProperties попадают параметры индивидуальные для каждого браузера
[request] => Array
        (
            [browser] => standard
            [modx_setup_language] => ru
            [_ga] => GA1.2.1805674015.1532178758
            [_ym_uid] => 1532178758631790336
            [_ym_d] => 1532178758
            [minishop2-category-grid-1] => {"start":0,"limit":"","action":"mgr/product/getlist","parent":"1"}
            [minishop2-category-grid-90] => {"start":0,"limit":"","action":"mgr/product/getlist","parent":"90"}
            [minishop2-category-grid-93] => {"start":0,"limit":"","action":"mgr/product/getlist","parent":"93"}
            [PHPSESSID] => 1f01ac36**********************************
            [_gid] => GA1.2.907764301.1533494910
            [_ym_isad] => 1
        )
То есть для каждого браузера генерируется отдельный кеш. Смысл кеша от этого пропадает :). 
Добавил
unset($options['setTotal']);
        unset($options['request']);
        return $key . '/' . sha1(serialize($options));