### PR TITLE
Устранение бага с загрузкой моделей в loadModels

### DIFF
--- a/core/components/pdotools/model/pdotools/pdotools.class.php
+++ b/core/components/pdotools/model/pdotools/pdotools.class.php
@@ -245,7 +245,7 @@ class pdoTools
             foreach ($tmp as $k => $v) {
                 if (!is_array($v)) {
                     $v = array(
-                        'path' => trim(strtolower($v)),
+                        'path' => trim($v),
                     );
                 }
                 $v = array_merge(array(


### PR DESCRIPTION
Путь до моделей не должен приводиться к нижнему регистру, иначе в 255 строке происходит некорректное сравнение.
Например MODX_CORE_PATH = /Users/ArtProg/Websites/site/www/core/
А путь до модели выглядел бы /users/artprog/websites/site/www/core/mycomponent/model/
И тогда после этого сравнения получается, что путь до модели меняется на /Users/ArtProg/Websites/site/www/core/users/artprog/websites/site/www/core/mycomponent/model/
Что в корне некорректно