### PR TITLE
[Fenom] Fix context data

### DIFF
--- a/core/components/pdotools/model/pdotools/_micromodx.php
+++ b/core/components/pdotools/model/pdotools/_micromodx.php
@@ -30,7 +30,8 @@ class microMODX
         $this->config = $modx->config;
 
         if ($modx->context) {
-            $this->context = $modx->context->toArray();
+            $context = $this->modx->getObject('modContext', array('key' => $modx->context->get('key')));
+            $this->context = $context->toArray();
         }
         if ($modx->resource) {
             $this->resource = $modx->resource->toArray();


### PR DESCRIPTION
## Summary
Fixed missing context data

### Steps to reproduce

This code: `{$_modx->context | print}` returns the following `Array ( [key] => web [name] => [description] => [rank] => 0)`

We'll get missing (null) name and description also wrong rank value.

### P.S.

I assume that the problem is in the MODX itself.
