### PR TITLE
Fix rewriting field `link` if field exists

### DIFF
--- a/core/components/pdotools/model/pdotools/pdofetch.class.php
+++ b/core/components/pdotools/model/pdotools/pdofetch.class.php
@@ -147,7 +147,7 @@ class pdoFetch extends pdoTools
                                 $row['link'] = $this->makeUrl($row['id'], $row);
                             }
                         } else {
-                            $row['link'] = '';
+                            $row['link'] = $row['link'] ?: '';
                         }
 
                         $tpl = $this->defineChunk($row);


### PR DESCRIPTION
У объектов, которые не являются ресурсами, может быть своё поле `link`. И в таком случае текущий код перезаписывает значение на пустоту.