### PR TITLE
Функция возвращает максимальный ID

### DIFF
--- a/core/components/pdotools/model/pdotools/_micromodx.php
+++ b/core/components/pdotools/model/pdotools/_micromodx.php
@@ -535,6 +535,19 @@ class microMODX
     {
         return modResource::filterPathSegment($this->modx, $alias);
     }
+    
+    /**
+     * @param string $class
+     *
+     * @return integer
+     */
+    public function maxPK($class = 'modResource')
+    {
+        $stmt = $this->modx->query("SELECT MAX({$this->modx->getPK($class)}) FROM {$this->modx->getTableName($class)}");
+        $maxPK = (integer) $stmt->fetch(PDO::FETCH_COLUMN);
+        $stmt->closeCursor();
+        return $maxPK;
+    }
 
 }
 


### PR DESCRIPTION
Полезно, когда нужно указать адрес ресурса (modResource) с уникальным url'ом, и он никак не получается из pagetitl'а.
Функция возвращает максимальный ID (либо другой primary key) любого класса
Пример вызова из fenom:
```
{$_modx->maxPK('modResource')}
```