### PR TITLE
additionalPlaceholders и вызов сниппета из @FILE

### DIFF
--- a/core/components/pdotools/elements/snippets/snippet.pdoresources.php
+++ b/core/components/pdotools/elements/snippets/snippet.pdoresources.php
@@ -10,7 +10,7 @@ if (!empty($returnIds)) {
 // Adding extra parameters into special place so we can put them in a results
 /** @var modSnippet $snippet */
 $additionalPlaceholders = $properties = array();
-if (isset($this) && $this instanceof modSnippet) {
+if (isset($this) && $this instanceof modSnippet && !empty($this->get('properties')) {
     $properties = $this->get('properties');
 }
 elseif ($snippet = $modx->getObject('modSnippet', array('name' => 'pdoResources'))) {


### PR DESCRIPTION
#289 
Возможность работать с additionalPlaceholders через вызов 
```
{$_modx->runSnippet('@FILE components/pdotools/elements/snippets/snippet.pdoresources.php', [
 'elementsPath'	=> $_modx->config.core_path,
```