### PR TITLE
условие if(isset($parent) &&  $parents=== '') всегда будет true

### DIFF
--- a/core/components/pdotools/elements/snippets/snippet.pdoresources.php
+++ b/core/components/pdotools/elements/snippets/snippet.pdoresources.php
@@ -1,6 +1,6 @@
 <?php
 /** @var array $scriptProperties */
-if (isset($parents) && $parents === '') {
+if (isset($parents) && $parents === '' && !(isset($resources) && $resources !== '')) {
     $scriptProperties['parents'] = $modx->resource->id;
 }
 if (!empty($returnIds)) {


### PR DESCRIPTION
Вне зависимости от того $parent передается  или нет. Если правильно понял, то это связано с pdotools.class.php:914 где загружаются параметры по умолчанию, в которых как раз есть parent и он равен ''.  В результате при вызове pdoResources с  &resources=`modResource.id, modResource.id, modResource.id` автоматически  добавляется parents = $modx->resource->id, хотя не должен.

Это приводит к тому, что pdoResources ничего не возвращает. Потому что modResource.id с таким modResource.parent нет в БД.