### PR TITLE
fix initill load when mode is "scroll"

### DIFF
--- a/assets/components/pdotools/js/pdopage.js
+++ b/assets/components/pdotools/js/pdopage.js
@@ -87,7 +87,7 @@ pdoPage.initialize = function (config) {
                 // Scroll pagination
                 var wrapper = $(config['wrapper']);
                 var $window = $(window);
-                $window.on('scroll', function () {
+                $window.on('load scroll', function () {
                     if (!pdoPage.Reached && $window.scrollTop() > wrapper.height() - $window.height()) {
                         pdoPage.Reached = true;
                         pdoPage.addPage(config);
@@ -168,6 +168,11 @@ pdoPage.loadPage = function (href, config, mode) {
                 }
                 else if (config['mode'] == 'scroll') {
                     pdoPage.Reached = false;
+					var $window = $(window);
+                    if ($window.scrollTop() > wrapper.height() - $window.height()) {
+                        pdoPage.Reached = true;
+                        pdoPage.addPage(config);
+                    }
                 }
             }
             else {


### PR DESCRIPTION
Речь только об ajaxMode = scroll.
Проблема возникает когда limit невелик, а экран большой или вертикально ориентирован. Т.е. событие scroll не будет вызвано никогда.
Возможно, есть более изящное решение, но в моем случае эти правки помогли.