### PR TITLE
Fix adding quotes to numeric values

### DIFF
--- a/core/components/pdotools/model/pdotools/pdofetch.class.php
+++ b/core/components/pdotools/model/pdotools/pdofetch.class.php
@@ -918,7 +918,11 @@ class pdoFetch extends pdoTools
                 if (!in_array($filter[0], $includeTVs)) {
                     $includeTVs[] = $filter[0];
                 }
-                $condition[] = $filter[0] . ' ' . $sqlOperator . ' ' . $this->modx->quote($filter[1]);
+                if(!is_numeric($filter[1])) {
+					$condition[] = $filter[0] . ' ' . $sqlOperator . ' ' . $this->modx->quote($filter[1]);
+				} else {
+					$condition[] = $filter[0] . ' ' . $sqlOperator . ' ' . $filter[1];
+				}
             }
             $conditions[] = implode(' AND ', $condition);
         }


### PR DESCRIPTION
Adding quotes to numeric values led to wrong "where" statement and therefore false results