### PR TITLE
Make cross context weblink url possible

### DIFF
--- a/core/components/pdotools/model/pdotools/pdomenu.class.php
+++ b/core/components/pdotools/model/pdotools/pdomenu.class.php
@@ -188,6 +188,7 @@ class pdoMenu
         }
 
         if (!empty($this->pdoTools->config['useWeblinkUrl']) && $row['class_key'] == 'modWebLink') {
+            unset($row['context_key']);
             $row['link'] = is_numeric(trim($row['content'], '[]~ '))
                 ? $this->pdoTools->makeUrl(intval(trim($row['content'], '[]~ ')), $row)
                 : $row['content'];


### PR DESCRIPTION
Otherwise $row['link'] is empty because makeUrl gets the wrong context_key