### PR TITLE
[Security] Fix reflected XSS in generated meta links (pdoPage)

### DIFF
--- a/core/components/pdotools/elements/snippets/snippet.pdopage.php
+++ b/core/components/pdotools/elements/snippets/snippet.pdopage.php
@@ -237,18 +237,21 @@ if ($isAjax) {
     exit(json_encode($data));
 } else {
     if (!empty($setMeta)) {
+        $charset = $modx->getOption('modx_charset', null, 'UTF-8');
         $canurl = $pdoPage->pdoTools->config['scheme'] !== 'full'
             ? rtrim($modx->getOption('site_url'), '/') . '/' . ltrim($url, '/')
             : $url;
-        $modx->regClientStartupHTMLBlock('<link rel="canonical" href="' . $canurl . '"/>');
+        $modx->regClientStartupHTMLBlock('<link rel="canonical" href="' . htmlentities($canurl, ENT_QUOTES, $charset) . '"/>');
         if ($data[$pageVarKey] > 1) {
+            $prevUrl = $pdoPage->makePageLink($canurl, $data[$pageVarKey] - 1);
             $modx->regClientStartupHTMLBlock(
-                '<link rel="prev" href="' . $pdoPage->makePageLink($canurl, $data[$pageVarKey] - 1) . '"/>'
+                '<link rel="prev" href="' . htmlentities($prevUrl, ENT_QUOTES, $charset) . '"/>'
             );
         }
         if ($data[$pageVarKey] < $data[$pageCountVar]) {
+            $nextUrl = $pdoPage->makePageLink($canurl, $data[$pageVarKey] + 1);
             $modx->regClientStartupHTMLBlock(
-                '<link rel="next" href="' . $pdoPage->makePageLink($canurl, $data[$pageVarKey] + 1) . '"/>'
+                '<link rel="next" href="' . htmlentities($nextUrl, ENT_QUOTES, $charset) . '"/>'
             );
         }
     }


### PR DESCRIPTION
[On the forum a user was looking for help identifying where a reflected XSS vulnerability came from](https://community.modx.com/t/problem-reflected-cross-site-scripting-xss-attack/3384), which [turned out to be in pdoPage](https://community.modx.com/t/problem-reflected-cross-site-scripting-xss-attack/3384/9?u=markh).

Specifically when pdoPage automatically generates the meta links, it does so [using the unsanitised url](https://github.com/bezumkin/pdoTools/blob/master/core/components/pdotools/model/pdotools/pdopage.class.php#L143) which then gets injected, causing the XSS issue.

Disabling the meta generation is one option but it's better to resolve this in the code. I'm not super familiar with the internals so I went to fix this in the place it gets inserted into the page.