### PR TITLE
Update pdofetch.class.php

### DIFF
--- a/core/components/pdotools/model/pdotools/pdofetch.class.php
+++ b/core/components/pdotools/model/pdotools/pdofetch.class.php
@@ -301,7 +301,7 @@ class pdoFetch extends pdoTools
                     $tmp = json_decode($tmp, true);
                 }
                 if ($join == 'leftJoin' && !empty($this->config['tvsJoin'])) {
-                    $tmp = array_merge($tmp, $this->config['tvsJoin']);
+                    $tmp = array_merge($this->config['tvsJoin'], $tmp);
                 }
                 foreach ($tmp as $k => $v) {
                     $class = !empty($v['class']) ? $v['class'] : $k;


### PR DESCRIPTION
str.304
Дело в том что если ты хочешь сравнить TV(список из кастомной таблицы) с кастомной таблицей, то TV присоединяются ниже по коду и соответственно ты не можешь обратиться к их значениям...
а так пожалуйста пользуй джойны TV и прибудет счастье