### PR TITLE
Fix makeUrl method properties

### DIFF
--- a/core/components/pdotools/src/Parsing/Fenom/Support/App.php
+++ b/core/components/pdotools/src/Parsing/Fenom/Support/App.php
@@ -143,9 +143,10 @@ class App
      */
     public function makeUrl($id, $context = '', $args = '', $scheme = -1, array $options = [])
     {
-        $this->pdoTools->debugParserMethod('makeUrl', $id, $args);
+        $properties = [$args, $scheme, $options];
+        $this->pdoTools->debugParserMethod('makeUrl', $id, $properties);
         $result = $this->modx->makeUrl($id, $context, $args, $scheme, $options);
-        $this->pdoTools->debugParserMethod('makeUrl', $id, $args);
+        $this->pdoTools->debugParserMethod('makeUrl', $id, $properties);
 
         return $result;
     }


### PR DESCRIPTION
### Что оно делает?

Исправляет ошибку при вызове метода `{$_modx->makeUrl()}`

### Зачем это нужно?

Метод `debugParserMethod` ожидает массив в качестве третьего аргумента, но `$args` - это строка (только иногда она может быть массивом, если это указано явно при вызове метода). В новой версии мы передаём именно массив со всеми важными аргументами.

### Связанные проблема(ы)/PR(ы)

–
