### PR TITLE
Update pdofetch.class.php

### DIFF
--- a/core/components/pdotools/model/pdotools/pdofetch.class.php
+++ b/core/components/pdotools/model/pdotools/pdofetch.class.php
@@ -939,7 +939,11 @@ class pdoFetch extends pdoTools
         }
 
         $this->config['includeTVs'] = implode(',', $includeTVs);
-        $this->config['where'] = $where;
+        if (is_array($this->config['where'])) {
+            $this->config['where'][] = $where;
+        } else {
+            $this->config['where'] = $where;
+        }
         $this->addTime('Added TVs filters', microtime(true) - $time);
     }
 


### PR DESCRIPTION
Что оно делает?
если указать что фильтр не заменяет массив конфига а дополняет то тогда получается совместить tvFilters и where
не знаю насколько будет верным решением...

Зачем это нужно?
совместить tvFilters и where