### PR TITLE
Fix prepareTVs and processTVs = 1 not working

### DIFF
--- a/core/components/pdotools/src/CoreTools.php
+++ b/core/components/pdotools/src/CoreTools.php
@@ -897,12 +897,12 @@ class CoreTools
         $prepare = $process = $prepareTypes = [];
         if (!empty($this->config['includeTVs']) && (!empty($this->config['prepareTVs']) || !empty($this->config['processTVs']))) {
             $tvs = array_map('trim', explode(',', $this->config['includeTVs']));
-            $prepare = ($this->config['prepareTVs'] === 1)
+            $prepare = ($this->config['prepareTVs'] == 1)
                 ? $tvs
                 : array_map('trim', explode(',', $this->config['prepareTVs']));
             $prepareTypes = array_map('trim',
                 explode(',', $this->modx->getOption('manipulatable_url_tv_output_types', null, 'image,file')));
-            $process = ($this->config['processTVs'] === 1)
+            $process = ($this->config['processTVs'] == 1)
                 ? $tvs
                 : array_map('trim', explode(',', $this->config['processTVs']));
 


### PR DESCRIPTION
prepateTVs = 1 and processTVs = 1 stopped working in v.3.0.0-Beta as the equality check changed to identity check.

But all values arriving from usual snippet calls and property sets arrive as string instead of number, making the "=== 1" check always fail, except maybe if calling the snippets by using the MODX runSnippet API.


