### PR TITLE
[3.0.0-beta] fatal error in connector.php

### DIFF
--- a/assets/components/pdotools/connector.php
+++ b/assets/components/pdotools/connector.php
@@ -5,7 +5,7 @@ require_once MODX_CORE_PATH . 'model/modx/modx.class.php';
 $modx = new modX();
 $modx->initialize('web');
 $modx->services->add('error', new MODX\Revolution\Error\modError($modx));
-$modx->error = $this->services->get('error');
+$modx->error = $modx->services->get('error');
 
 // Switch context if needed
 if (!empty($_REQUEST['pageId'])) {


### PR DESCRIPTION
### Что оно делает?

Fixes error in connector.php.

### Зачем это нужно?

Code throws fatal error: "Uncaught Error: Using $this when not in object context"

### Связанные проблема(ы)/PR(ы)

https://community.modx.com/t/pdopage-fails-with-500-error/5182
