### PR TITLE
Update snippet.pdoresources.php

### DIFF
--- a/core/components/pdotools/elements/snippets/snippet.pdoresources.php
+++ b/core/components/pdotools/elements/snippets/snippet.pdoresources.php
@@ -54,8 +54,11 @@ if (!empty($returnIds)) {
     $modx->setPlaceholders($output, $toSeparatePlaceholders);
 } else {
     if (!empty($tplWrapper) && (!empty($wrapIfEmpty) || !empty($output))) {
-        $output = $pdoFetch->getChunk($tplWrapper, array_merge($additionalPlaceholders, ['output' => $output]),
-            $pdoFetch->config['fastMode']);
+        $output = $pdoFetch->getChunk(
+            $tplWrapper, 
+            array_merge( $additionalPlaceholders,['output' => $output] ),
+            $pdoFetch->getConfig['fastMode']
+        );
     }
 
     if (!empty($toPlaceholder)) {


### PR DESCRIPTION
PR solves this problem:

AH01071: Got error 'PHP message: PHP Fatal error: Uncaught Error: Cannot access protected property ModxPro\\PdoTools\\Fetch::$config in /var/www/vhosts/example.com/httpdocs/web/core/cache/includes/elements/modx/revolution/modsnippet/19.include.cache.php:57\nStack trace:\n

use getConfig instead of config (see: https://github.com/modx-pro/pdoTools/issues/334)
