### PR TITLE
MODX 3 - Fix &processTVs=1

### DIFF
--- a/core/components/pdotools/src/CoreTools.php
+++ b/core/components/pdotools/src/CoreTools.php
@@ -897,12 +897,12 @@ class CoreTools
         $prepare = $process = $prepareTypes = [];
         if (!empty($this->config['includeTVs']) && (!empty($this->config['prepareTVs']) || !empty($this->config['processTVs']))) {
             $tvs = array_map('trim', explode(',', $this->config['includeTVs']));
-            $prepare = ($this->config['prepareTVs'] === 1)
+            $prepare = ($this->config['prepareTVs'] == 1)
                 ? $tvs
                 : array_map('trim', explode(',', $this->config['prepareTVs']));
             $prepareTypes = array_map('trim',
                 explode(',', $this->modx->getOption('manipulatable_url_tv_output_types', null, 'image,file')));
-            $process = ($this->config['processTVs'] === 1)
+            $process = ($this->config['processTVs'] == 1)
                 ? $tvs
                 : array_map('trim', explode(',', $this->config['processTVs']));
 


### PR DESCRIPTION
### Что оно делает?

In MODX 3, `` &processTVs=`1` `` doesn't work anymore.

See corresponding topic in the MODX forum:
https://community.modx.com/t/output-of-image-path-with-pdoresources-and-modx-3-0-1/5561