### PR TITLE
added missing type cast for config['offset']

### DIFF
--- a/core/components/pdotools/model/pdotools/pdotools.class.php
+++ b/core/components/pdotools/model/pdotools/pdotools.class.php
@@ -634,11 +634,11 @@ class pdoTools
     public function defineChunk($properties = array())
     {
         $idx = isset($properties['idx']) ? (integer)$properties['idx'] : $this->idx++;
-        $idx -= $this->config['offset'];
+        $idx -= (integer)$this->config['offset'];
 
-        $first = empty($this->config['first']) ? ($this->config['offset'] + 1) : (integer)$this->config['first'];
+        $first = empty($this->config['first']) ? ((integer)$this->config['offset'] + 1) : (integer)$this->config['first'];
         $last = empty($this->config['last'])
-            ? ($this->count + $this->config['offset'])
+            ? ($this->count + (integer)$this->config['offset'])
             : (integer)$this->config['last'];
 
         $odd = !($idx & 1);


### PR DESCRIPTION
fix for php 8 arithmetic on config->offset.

### Что оно делает?

Added integer type casting for config['offset'], where necessary. While I haven't scoured all Type casting

### Зачем это нужно?

Fetch breaks on php 8 without this fix, or something like this fix.

### Связанные проблема(ы)/PR(ы)
