### PR TITLE
Add type casts

### DIFF
--- a/core/components/pdotools/src/Parsing/Fenom/Fenom.php
+++ b/core/components/pdotools/src/Parsing/Fenom/Fenom.php
@@ -242,6 +242,13 @@ class Fenom extends \Fenom
                 'number' => 'number_format',
                 'reset' => 'reset',
                 'end' => 'end',
+                
+                // Casts
+                'boolval' => 'boolval',
+                'doubleval' => 'doubleval',
+                'floatval' => 'floatval',
+                'intval' => 'intval',
+                'strval' => 'strval',
             ]
         );
 


### PR DESCRIPTION
Adds Fenom type casting modifiers (`boolval, floatval, intval, strval`) to allow explicit casting of variables to the desired type in templates.