### PR TITLE
Включить функцию array_merge по умолчанию

### DIFF
--- a/core/components/pdotools/model/pdotools/_fenom.php
+++ b/core/components/pdotools/model/pdotools/_fenom.php
@@ -113,6 +113,7 @@ class FenomX extends Fenom
             array(
                 'rand' => 1,
                 'number_format' => 1,
+                'array_merge' => 1,
             )
         );
 


### PR DESCRIPTION
Предлагаю включить функцию, которая часто необходима - **array_merge**.  Она описывается в документации, но по факту не включена. А хотелось бы чтобы была. Иногда встречались в чате вопросы почему не работает, ведь в доке есть. Спасибо.

### Зачем это нужно?

Нужно чтобы объединять массивы без затирания друг-друга.


