### PR TITLE
Поддержка файловых сниппетов в pdoPage

### DIFF
--- a/core/components/pdotools/src/CoreTools.php
+++ b/core/components/pdotools/src/CoreTools.php
@@ -677,9 +677,9 @@ class CoreTools
         $binding = $content = $propertySet = '';
 
         $name = trim($name);
-        if (preg_match('#^@([A-Z]+)#', $name, $matches)) {
+        if (preg_match('#^!?@([A-Z]+)#', $name, $matches)) {
             $binding = $matches[1];
-            $content = substr($name, strlen($binding) + 1);
+            $content = preg_replace('#^!?@' . $binding . '#', '', $name);
             $content = ltrim($content, ' :');
         }
         // Get property set


### PR DESCRIPTION
[С некоторых пор](https://github.com/modx-pro/pdoTools/commit/ab4934d190c67622dcc4b005193249da0ada07f0#diff-df1b56538c6abe3aefac65ce5f4a027cc988cb15e21882bb272cdcb06281c2f5R142) `pdoPage` вызывает все сниппеты в `element` некэшируемыми, принудительно подставляя восклицательный знак перед именем.

Это ломает работу файловых сниппетов:
```
{'!pdoPage' | snippet : [
    'element' => '@FILE elements/snippets/overview.snippet.php',
    'tplPage' => '@FILE elements/chunks/pagination/page.tpl',
    'tplPageWrapper' => '@FILE elements/chunks/pagination/page-wrapper.tpl'
]}
```

Имя получается `!@FILE elements...`, собачка на 1й позиции считается за Property Set и сниппет не может быть загружен.

Данное изменение это исправляет, позволяя указывать восклицательный знак и для элементов c биндингами.
