### PR TITLE
Upgrade Fenom to v3 with php 8 support

### DIFF
--- a/_build/build.config.php
+++ b/_build/build.config.php
@@ -4,7 +4,7 @@
 define('PKG_NAME', 'pdoTools');
 define('PKG_NAME_LOWER', strtolower(PKG_NAME));
 
-define('PKG_VERSION', '2.13.2');
+define('PKG_VERSION', '2.14.0');
 define('PKG_RELEASE', 'pl');
 define('PKG_AUTO_INSTALL', false);
 

--- a/core/components/pdotools/composer.json
+++ b/core/components/pdotools/composer.json
@@ -2,6 +2,6 @@
     "name": "bezumkin/pdotools",
     "type": "library",
     "require": {
-        "fenom/fenom": "2.*"
+        "fenom/fenom": "3.*"
     }
 }

--- a/core/components/pdotools/composer.lock
+++ b/core/components/pdotools/composer.lock
@@ -4,34 +4,33 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5722bbf5b6cd9e745169bc308c88ecd3",
+    "content-hash": "fd7de43fdf50f5f253a6b354302c5803",
     "packages": [
         {
             "name": "fenom/fenom",
-            "version": "2.12.0",
+            "version": "v3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/fenom-template/fenom.git",
-                "reference": "f0cb251843de469b453b15c158cf0d1589d4de6d"
+                "reference": "fbf4f46f1fe1d7d3cc342996e8e71d42b6b1ecdb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/fenom-template/fenom/zipball/f0cb251843de469b453b15c158cf0d1589d4de6d",
-                "reference": "f0cb251843de469b453b15c158cf0d1589d4de6d",
+                "url": "https://api.github.com/repos/fenom-template/fenom/zipball/fbf4f46f1fe1d7d3cc342996e8e71d42b6b1ecdb",
+                "reference": "fbf4f46f1fe1d7d3cc342996e8e71d42b6b1ecdb",
                 "shasum": ""
             },
             "require": {
                 "ext-tokenizer": "*",
-                "php": ">=5.3.0"
+                "php": ">=8.0.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "<6.0",
-                "satooshi/php-coveralls": "*"
+                "phpunit/phpunit": "9.*"
             },
             "type": "library",
             "autoload": {
-                "psr-0": {
-                    "Fenom\\": "src/"
+                "psr-4": {
+                    "Fenom\\": "src/Fenom"
                 },
                 "classmap": [
                     "src/Fenom.php"
@@ -39,7 +38,7 @@
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
-                "BSD-3"
+                "BSD-3-Clause"
             ],
             "authors": [
                 {
@@ -56,9 +55,9 @@
             ],
             "support": {
                 "issues": "https://github.com/fenom-template/fenom/issues",
-                "source": "https://github.com/fenom-template/fenom/tree/2.12.0"
+                "source": "https://github.com/fenom-template/fenom/tree/v3.0.0"
             },
-            "time": "2020-07-06T17:02:31+00:00"
+            "time": "2023-02-27T08:38:43+00:00"
         }
     ],
     "packages-dev": [],
@@ -69,5 +68,5 @@
     "prefer-lowest": false,
     "platform": [],
     "platform-dev": [],
-    "plugin-api-version": "2.0.0"
+    "plugin-api-version": "2.3.0"
 }

--- a/core/components/pdotools/docs/changelog.txt
+++ b/core/components/pdotools/docs/changelog.txt
@@ -1,5 +1,9 @@
 Changelog for pdoTools.
 
+2.14.0-pl (02.04.2023)
+==============
+- Fenom updated to 3.0 to be compatible with PHP 8.
+
 2.13.2-pl (02.09.2021)
 ==============
 - Fixed some snippets.

--- a/core/components/pdotools/model/fenom/Providers/ModChunk.php
+++ b/core/components/pdotools/model/fenom/Providers/ModChunk.php
@@ -20,7 +20,7 @@ class modChunkProvider implements \Fenom\ProviderInterface
      *
      * @return bool
      */
-    public function templateExists($tpl)
+    public function templateExists(string $tpl): bool
     {
         $c = is_numeric($tpl) && $tpl > 0
             ? $tpl
@@ -36,7 +36,7 @@ class modChunkProvider implements \Fenom\ProviderInterface
      *
      * @return string
      */
-    public function getSource($tpl, &$time)
+    public function getSource(string $tpl, float &$time): string
     {
         $content = '';
         if ($pos = strpos($tpl, '@')) {
@@ -76,7 +76,7 @@ class modChunkProvider implements \Fenom\ProviderInterface
      *
      * @return int
      */
-    public function getLastModified($tpl)
+    public function getLastModified(string $tpl): float
     {
         $c = is_numeric($tpl) && $tpl > 0
             ? $tpl
@@ -99,7 +99,7 @@ class modChunkProvider implements \Fenom\ProviderInterface
      *
      * @return bool if true - all templates are valid else some templates are invalid
      */
-    public function verify(array $templates)
+    public function verify(array $templates): bool
     {
         return true;
     }
@@ -109,7 +109,7 @@ class modChunkProvider implements \Fenom\ProviderInterface
      * Get all names of template from provider
      * @return array|\Iterator
      */
-    public function getList()
+    public function getList(string $extension = "tpl"): iterable
     {
         $c = $this->modx->newQuery('modChunk');
         $c->select('name');

--- a/core/components/pdotools/model/fenom/Providers/ModTemplate.php
+++ b/core/components/pdotools/model/fenom/Providers/ModTemplate.php
@@ -20,7 +20,7 @@ class modTemplateProvider implements \Fenom\ProviderInterface
      *
      * @return bool
      */
-    public function templateExists($tpl)
+    public function templateExists(string $tpl): bool
     {
         $c = is_numeric($tpl) && $tpl > 0
             ? $tpl
@@ -36,7 +36,7 @@ class modTemplateProvider implements \Fenom\ProviderInterface
      *
      * @return string
      */
-    public function getSource($tpl, &$time)
+    public function getSource(string $tpl, float &$time): string
     {
         $content = '';
         if ($pos = strpos($tpl, '@')) {
@@ -76,7 +76,7 @@ class modTemplateProvider implements \Fenom\ProviderInterface
      *
      * @return int
      */
-    public function getLastModified($tpl)
+    public function getLastModified(string $tpl): float
     {
         $c = is_numeric($tpl) && $tpl > 0
             ? $tpl
@@ -99,7 +99,7 @@ class modTemplateProvider implements \Fenom\ProviderInterface
      *
      * @return bool if true - all templates are valid else some templates are invalid
      */
-    public function verify(array $templates)
+    public function verify(array $templates): bool
     {
         return true;
     }
@@ -109,7 +109,7 @@ class modTemplateProvider implements \Fenom\ProviderInterface
      * Get all names of template from provider
      * @return array|\Iterator
      */
-    public function getList()
+    public function getList(string $extension = "tpl"): iterable
     {
         $c = $this->modx->newQuery('modTemplate');
         $c->select('templatename');

--- a/core/components/pdotools/model/pdotools/_fenom.php
+++ b/core/components/pdotools/model/pdotools/_fenom.php
@@ -72,7 +72,7 @@ class FenomX extends Fenom
      * @throws LogicException
      * @return Fenom
      */
-    public function setCompileDir($dir)
+    public function setCompileDir(string $dir): static
     {
         $dir = str_replace(MODX_CORE_PATH, '', $dir);
         $path = MODX_CORE_PATH;
@@ -646,7 +646,7 @@ class FenomX extends Fenom
      *
      * @return Closure
      */
-    protected function _loadModifier($name, $template)
+    protected function _loadModifier(string $name, Fenom\Template $template): ?string
     {
         $modx = $this->modx;
         $pdo = $this->pdoTools;

--- a/core/components/pdotools/model/pdotools/_fenom.php
+++ b/core/components/pdotools/model/pdotools/_fenom.php
@@ -2,7 +2,6 @@
 
 if (!class_exists('Fenom')) {
     require dirname(dirname(dirname(__FILE__))) . '/vendor/autoload.php';
-    Fenom::registerAutoload();
 }
 
 class FenomX extends Fenom


### PR DESCRIPTION
### Что оно делает? 

Обновляет зависимость для поддержки версии PHP от 8.0 и выше

### Зачем это нужно?

Сейчас при использовании старой версии использование модификатора match роняет сайт с ошибкой 500

### Связанные проблема(ы)/PR(ы)

N/A
