### PR TITLE
bugfix pdoResources snippet, $output string to placeholders

### DIFF
--- a/core/components/pdotools/elements/snippets/snippet.pdoresources.php
+++ b/core/components/pdotools/elements/snippets/snippet.pdoresources.php
@@ -55,8 +55,12 @@ if (!empty($returnIds)) {
 } elseif ($return === 'data') {
     return $output;
 } elseif (!empty($toSeparatePlaceholders)) {
-    $output['log'] = $log;
-    $modx->setPlaceholders($output, $toSeparatePlaceholders);
+    if(is_array($log)){
+        $output['log'] = $log;
+        $modx->setPlaceholders($output, $toSeparatePlaceholders);
+    }else {
+        $modx->setPlaceholders(['log' => $log], $toSeparatePlaceholders);
+    }
 } else {
     $output .= $log;
 


### PR DESCRIPTION
### Что оно делает?
Check if $ouput is an array before adding the $log result when property $toSeparatePlaceholders is set.

### Зачем это нужно?
Uncaught TypeError in PHP >= 8

### Связанные проблема(ы)/PR(ы)
#372 
