### PR TITLE
Fix a too strict check

### DIFF
--- a/core/components/pdotools/src/Support/Paginator.php
+++ b/core/components/pdotools/src/Support/Paginator.php
@@ -316,7 +316,7 @@ class Paginator
                 break;
             }
 
-            if ($page === $i && !empty($this->pdoTools->config('tplPageActive'))) {
+            if ($page == $i && !empty($this->pdoTools->config('tplPageActive'))) {
                 $tpl = $this->pdoTools->config('tplPageActive');
             } elseif (!empty($this->pdoTools->config('tplPage'))) {
                 $tpl = $this->pdoTools->config('tplPage');


### PR DESCRIPTION
$page contains an integer and $i contains a float during my tests

### What does it do?

Switch to a less restrictive check. In my case the value of $page is an integer and the value of $i is a float. For whatever reason this check was invalid only when the $page is 15 on PHP 8.3.20.

### Why is it needed?

To display the active page on page 15 too.