### PR TITLE
fix(Fetch.php): warning when preparing condition for log message

### DIFF
--- a/core/components/pdotools/src/Fetch.php
+++ b/core/components/pdotools/src/Fetch.php
@@ -222,7 +222,8 @@ class Fetch extends CoreTools
         $where = $this->additionalConditions($where);
         if (!empty($where)) {
             $this->query->where($where);
-            $this->addTime('Added where condition: <b>' . json_encode($where) . '</b>', microtime(true) - $time);
+            $whereLog = json_encode($where);
+            $this->addTime('Added where condition: ' . ($whereLog !== false ? $whereLog : print_r($where, true)) . ' ', microtime(true) - $time);
         }
         $time = microtime(true);
         if (!empty($this->config['having'])) {
@@ -235,7 +236,8 @@ class Fetch extends CoreTools
             }
             $having = $this->replaceTVCondition($tmp);
             $this->query->having($having);
-            $this->addTime('Added having condition: <b>' . json_encode($having) . '</b>', microtime(true) - $time);
+            $havingLog = json_encode($having);
+            $this->addTime('Added having condition: ' . ($havingLog !== false ? $havingLog : print_r($having, true)) . ' ', microtime(true) - $time);
         }
     }
 

--- a/core/components/pdotools/src/Fetch.php
+++ b/core/components/pdotools/src/Fetch.php
@@ -222,21 +222,7 @@ class Fetch extends CoreTools
         $where = $this->additionalConditions($where);
         if (!empty($where)) {
             $this->query->where($where);
-            $condition = [];
-            foreach ($where as $k => $v) {
-                if (is_array($v)) {
-                    if (isset($v[0])) {
-                        $condition[] = is_array($v) ? $k . '(' . implode(',', $v) . ')' : $k . '=' . $v;
-                    } else {
-                        foreach ($v as $k2 => $v2) {
-                            $condition[] = is_array($v2) ? $k2 . '(' . implode(',', $v2) . ')' : $k2 . '=' . $v2;
-                        }
-                    }
-                } else {
-                    $condition[] = $k . '=' . $v;
-                }
-            }
-            $this->addTime('Added where condition: <b>' . implode(', ', $condition) . '</b>', microtime(true) - $time);
+            $this->addTime('Added where condition: <b>' . json_encode($where) . '</b>', microtime(true) - $time);
         }
         $time = microtime(true);
         if (!empty($this->config['having'])) {
@@ -249,16 +235,7 @@ class Fetch extends CoreTools
             }
             $having = $this->replaceTVCondition($tmp);
             $this->query->having($having);
-
-            $condition = [];
-            foreach ($having as $k => $v) {
-                if (is_array($v)) {
-                    $condition[] = $k . '(' . implode(',', $v) . ')';
-                } else {
-                    $condition[] = $k . '=' . $v;
-                }
-            }
-            $this->addTime('Added having condition: <b>' . implode(', ', $condition) . '</b>', microtime(true) - $time);
+            $this->addTime('Added having condition: <b>' . json_encode($having) . '</b>', microtime(true) - $time);
         }
     }
 


### PR DESCRIPTION
### Что оно делает?

Исправляет warning при подготовке сообщения для логирования
```
[2025-08-15 10:53:13] (ERROR @ /var/www/public/core/components/pdotools/src/Fetch.php : 229) PHP warning: Array to string conversion
```

### Описание проблемы

Исходя из документации по [xPDOQuery::where](https://docs.modx.com/current/en/extending-modx/xpdo/class-reference/xpdoquery/xpdoquery.where) Этот запрос может быть комплексным и включать в себя многомерный массив. Из за этого функция implode принимает значения, которые не может обработать.

В качестве примера вот такой запрос WHERE отлично парсится и отрабатывает в MODX, но выдает WARNING в коде, который предназначен для подготовки WHERE запроса к логировалию (Смотрите пример предупреждения выше):
```php
[
    [
        [
            "TVtags.value:LIKE" => "%hit%"
        ],
        [
            "OR:TVtags.value:LIKE" => "%promo%"
        ],
        [
            "OR:TVtags.value:LIKE" => "%sale%"
        ],
    ],
    [
        "TVprice.value:>=" => 104,
        "AND:TVprice.value:<=" => 140
    ],
    "modResource.parent:IN" => [5],
    "modResource.template:IN" => [3],
    "modResource.published" => 1,
    "modResource.deleted" => 0
]
```

Обратите внимание на различие TVprice и TVtags. Из за того, что TVtags могут иметь несколько значений, мы не можем иметь одну вложенность массива (иначе ключ "OR:TVtags.value:LIKE" будет повторяться, и значения будут переписаны, а не добавлены):
```php
// Этот участок кода не работает из за повторяющегося ключа массива
 [
    [
        "TVtags.value:LIKE" => "%hit%",
        "OR:TVtags.value:LIKE" => "%promo%", //<-- Ключь массива установлен
        "OR:TVtags.value:LIKE" => "%sale%" //<-- Значение перепишет предыдущий ключь
    ]
]
```

Поэтому мы можем передать многомерный массив в xPDOQuery.

Парсер xPDOQuery обрабатывает такие массивы рекурсивно, с любым уровнем вложенности.

---

Предлагаю заменить логирование WHERE (и заодно и HAVING чуть ниже) на json_encode - это выведет в сообщения логов более четкую информацию о том, что именно попало в WHERE и так же снизит количество warning (и error в будущих версиях PHP).
