### PR TITLE
Add scriptProperties values as placeholder to the pagination

### DIFF
--- a/core/components/pdotools/elements/snippets/snippet.pdopage.php
+++ b/core/components/pdotools/elements/snippets/snippet.pdopage.php
@@ -200,8 +200,8 @@ if (empty($data)) {
         $pageVarKey => $page,
         $pageCountVar => $pageCount,
         $pageNavVar => !empty($tplPageWrapper)
-            ? $pdoPage->pdoTools->getChunk($tplPageWrapper, $pagination)
-            : $pdoPage->pdoTools->parseChunk('', $pagination),
+            ? $pdoPage->pdoTools->getChunk($tplPageWrapper, array_merge($scriptProperties, $pagination))
+            : $pdoPage->pdoTools->parseChunk('', array_merge($scriptProperties, $pagination)),
         $totalVar => $total,
     ];
     if ($cache) {


### PR DESCRIPTION
Add scriptProperties values as placeholder to the pagination. This is quite useful, if you need to fill special properties into special placeholders in the pagination links. Otherwise you have to create several pagination chunks with the special properties.
