### PR TITLE
Hotfix/block shell execution

### DIFF
--- a/_build/build.config.php
+++ b/_build/build.config.php
@@ -3,7 +3,7 @@
 const PKG_NAME = 'pdoTools';
 const PKG_NAME_LOWER = 'pdotools';
 
-const PKG_VERSION = '3.0.2';
+const PKG_VERSION = '3.0.3';
 const PKG_RELEASE = 'pl';
 const PKG_AUTO_INSTALL = false;
 

--- a/core/components/pdotools/docs/changelog.txt
+++ b/core/components/pdotools/docs/changelog.txt
@@ -1,5 +1,9 @@
 Changelog for pdoTools.
 
+3.0.3-pl (01.04.2026)
+==============
+- Security fix for the Fenom parser.
+
 3.0.2-pl (11.04.2023)
 ==============
 - Support for file snippets in the pdoPage class.

--- a/core/components/pdotools/src/Parsing/Fenom/Fenom.php
+++ b/core/components/pdotools/src/Parsing/Fenom/Fenom.php
@@ -69,6 +69,43 @@ class Fenom extends \Fenom
             ]
         );
     }
+    
+    /**
+     * Dangerous PHP functions that must never be callable from Fenom templates,
+     * even when useFenomPHP is enabled. Covers command execution, file system
+     * manipulation, code evaluation, and network operations.
+     */
+    protected const BLACKLISTED_FUNCTIONS = [
+        'system', 'exec', 'shell_exec', 'passthru', 'popen', 'proc_open',
+        'pcntl_exec', 'eval', 'assert', 'create_function',
+        'call_user_func', 'call_user_func_array',
+        'file_put_contents', 'file_get_contents', 'fopen', 'fwrite', 'fread',
+        'readfile', 'unlink', 'rmdir', 'mkdir', 'rename', 'copy', 'move_uploaded_file',
+        'curl_init', 'curl_exec', 'curl_multi_exec',
+        'mail', 'header', 'setcookie',
+        'putenv', 'ini_set', 'dl',
+        'chmod', 'chown', 'chgrp',
+        'preg_replace_callback', 'ob_start',
+    ];
+
+    /**
+     * Override parent to block dangerous functions regardless of useFenomPHP setting.
+     *
+     * @param string $function
+     * @return bool
+     */
+    public function isAllowedFunction($function)
+    {
+        if (in_array(strtolower($function), self::BLACKLISTED_FUNCTIONS, true)) {
+            $this->modx->log(
+                modX::LOG_LEVEL_ERROR,
+                '[pdoTools/Fenom] Blocked dangerous function call: ' . $function
+            );
+            return false;
+        }
+
+        return parent::isAllowedFunction($function);
+    }
 
     /**
      * Parse content with Fenom syntax


### PR DESCRIPTION
My best Russian

### Что это делает?

Вносит в черный список определенные функции, выполнение которых нежелательно при включенном PHP в Fenom.

### Зачем это нужно?

Предотвращает уязвимости типа «бэкдор».